### PR TITLE
Implement -ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Examples:
     $ gocyclo -top 10 src/
     $ gocyclo -over 25 docker
     $ gocyclo -avg .
+    $ gocyclo -ignore "_test|Godeps" .
 
 The output fields for each line are:
 


### PR DESCRIPTION
This PR implements the possibility to ignore files that match the given regular expression.
Fixes #9, #4 (generic approach).

Example:

```
$ gocyclo -ignore "yacc|\.pb\.|Godeps" .
```
