### PR TITLE
Fix cyclomatic complexity

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@
 
 Frederik Zipp <fzipp@gmx.de>
 Harshavardhana <harsha@harshavardhana.net>
+Nodir Turakulov <turakulov@gmail.com>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ For more information on the metric refer to https://en.wikipedia.org/wiki/Cyclom
 
 To install, run
 
-    $ go get github.com/nodirt/gocyclo
+    $ go get github.com/fzipp/gocyclo
 
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,14 @@
-Gocyclo calculates cyclomatic complexities of functions in Go source code.
+Command gocyclo calculates cyclomatic complexities of functions in Go source code.
 
-The cyclomatic complexity of a function is calculated according to the
-following rules:
-
-     1 is the base complexity of a function
-    +1 for each 'if', 'for', 'case', '&&' or '||'
+For more information on the metric refer to https://en.wikipedia.org/wiki/Cyclomatic_complexity.
 
 To install, run
 
-    $ go get github.com/fzipp/gocyclo
-
-and put the resulting binary in one of your PATH directories if
-`$GOPATH/bin` isn't already in your PATH.
+    $ go get github.com/nodirt/gocyclo
 
 Usage:
 
-    $ gocyclo [<flag> ...] <Go file or directory> ...
+    $ gocyclo [<flag> ...] <Go file or package> ...
 
 Examples:
 
@@ -27,5 +20,4 @@ Examples:
 
 The output fields for each line are:
 
-    <complexity> <package> <function> <file:row:column>
-
+    <complexity> <full function name> <file:row:column>


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Cyclomatic_complexity has the following definition

> The cyclomatic complexity of a section of source code is the number of linearly independent paths within it

The current version of the code does not count linearly independent code paths. Instead it counts branch points. This is different. For example, cyclomatic complexity of

```go
if a {
  if b {
  } else {
  }
} else {
}
```

and

```go
if a {
} else {
}
if b {
} else {
}
```
must be different, but current implementation would return same value.

This PR rewrites the computation algorithm.
