### PR TITLE
add -pkgAvg to summarize average by package

### DIFF
--- a/gocyclo.go
+++ b/gocyclo.go
@@ -42,7 +42,9 @@ Flags:
         -top N    show the top N most complex functions only
         -avg      show the average complexity over all functions,
                   not depending on whether -over or -top are set
-
+        -pkgAvg   show the average complexity over all functions,
+				  in a package not depending on whether -over or
+				  -top are set
 The output fields for each line are:
 <complexity> <package> <function> <file:row:column>
 `
@@ -53,9 +55,10 @@ func usage() {
 }
 
 var (
-	over = flag.Int("over", 0, "show functions with complexity > N only")
-	top  = flag.Int("top", -1, "show the top N most complex functions only")
-	avg  = flag.Bool("avg", false, "show the average complexity")
+	over   = flag.Int("over", 0, "show functions with complexity > N only")
+	top    = flag.Int("top", -1, "show the top N most complex functions only")
+	avg    = flag.Bool("avg", false, "show the average complexity")
+	pkgAvg = flag.Bool("pkgAvg", false, "show the average complexity by package")
 )
 
 func main() {
@@ -74,6 +77,10 @@ func main() {
 
 	if *avg {
 		showAverage(stats)
+	}
+
+	if *pkgAvg {
+		showStatsByPkg(stats)
 	}
 
 	if *over > 0 && written > 0 {
@@ -140,6 +147,26 @@ func average(stats []stat) float64 {
 		total += s.Complexity
 	}
 	return float64(total) / float64(len(stats))
+}
+
+func showStatsByPkg(stats []stat) {
+	pkgStats := statsByPkg(stats)
+
+	for pkg, s := range pkgStats {
+		fmt.Printf("%.3g %s Average\n", average(s), pkg)
+	}
+}
+
+func statsByPkg(stats []stat) map[string][]stat {
+	pkgStats := map[string][]stat{}
+	for _, s := range stats {
+		if _, ok := pkgStats[s.PkgName]; ok {
+			pkgStats[s.PkgName] = append(pkgStats[s.PkgName], s)
+		} else {
+			pkgStats[s.PkgName] = []stat{}
+		}
+	}
+	return pkgStats
 }
 
 type stat struct {


### PR DESCRIPTION
Add `-pkgAvg` flag to compute averages by package name. This is useful for large codebases. 

Attempts to follow the coding and formatting of the existing codebase. 