### PR TITLE
Add a flag to print average complexity in a short format

### DIFF
--- a/gocyclo.go
+++ b/gocyclo.go
@@ -13,7 +13,6 @@
 //                return exit code 1 if the output is non-empty
 //      -top N    show the top N most complex functions only
 //      -avg      show the average complexity
-//      -skiptest skip test files when calculating complexity
 //      -short    only print the average without additional
 //                formatting or output, ignores all other options
 //


### PR DESCRIPTION
This is useful in CI scenarios where we want to fail or warn over a certain upper-limit for average complexity, but don't want to do a bunch of shell acrobatics to get this number.